### PR TITLE
Add support for charts that have dependencies

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -2,7 +2,7 @@
 set -e
 
 if [[ $(uname -s) == 'Darwin' ]]; then 
-	echo "Please make sure you have helm and yq installed"
+	echo "Please make sure you have helm v3 and yq v3 installed"
 	exit 0
 fi
 

--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -27,7 +27,7 @@ for f in packages/*; do
 				curl -sLf ${url} | tar xvzf - -C ${f}/charts-original --strip ${fields} ${subdirectory} > /dev/null 2>&1
 			fi
 			if [[ -d ${f}/charts ]]; then
-				diff -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
+				diff -x *.tgz -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
 			fi
 			rm -rf ${f}/charts-original
 		fi

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -33,6 +33,10 @@ for f in packages/*; do
 				basename=$(basename -- ${file})
 				patch -p3 -d ${f}/charts < ${f}/$basename
 			done
+			pwd=$(pwd)
+			cd ${f}/charts
+			helm dependency update
+			cd $pwd
 		fi
   fi
 done


### PR DESCRIPTION
This PR updates the prepare script to do a dependency update after applying a patch and updates the generate-path script to ignore .tgz files that will be generated per dependency.

It also makes a minor change to the bootstrap script to note that helm v3 and yq v3 is required.