### PR TITLE
Add support for local charts in overlay

### DIFF
--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -27,7 +27,7 @@ for f in packages/*; do
 				curl -sLf ${url} | tar xvzf - -C ${f}/charts-original --strip ${fields} ${subdirectory} > /dev/null 2>&1
 			fi
 			if [[ -d ${f}/charts ]]; then
-				diff -x *.tgz -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
+				diff -x *.tgz -x *.lock -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
 			fi
 			rm -rf ${f}/charts-original
 		fi

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -33,10 +33,27 @@ for f in packages/*; do
 				basename=$(basename -- ${file})
 				patch -p3 -d ${f}/charts < ${f}/$basename
 			done
+			copied_dependencies=()
+			if [[ -f ${f}/charts/requirements.yaml ]]; then
+				repos=$(cat ${f}/charts/requirements.yaml | yq r - "dependencies.*.repository")
+				while IFS= read -r repo; do
+					if [[ ${repo} == file://* ]]; then
+						charts_path=${repo/file:\/\//${f}/charts/}
+						overlay_path=${repo/file:\/\//${f}/overlay/}
+						if [[ ! -d $charts_path ]] && [[ -d $overlay_path ]]; then
+							cp -R $overlay_path $charts_path
+							copied_dependencies+=("${charts_path}")
+						fi
+					fi
+				done < <(echo "${repos}")
+			fi
 			pwd=$(pwd)
 			cd ${f}/charts
 			helm dependency update
 			cd $pwd
+			for dep in "${copied_dependencies[@]}"; do
+				rm -rf $dep
+			done
 		fi
   fi
 done


### PR DESCRIPTION
This PR adds support for adding local charts to the overlay.

On prepare, it adds any local chart archives mentioned in `requirements.yaml` that do not currently exist in `charts/` but do exist in `overlay/` to the `charts/` directory, while keeping track of those directories that have been added. Then, after the `helm dependency update` has created the necessary binary in the charts directory, it removes the directories that it added in the previous step.

This leaves an extra binary behind in the `charts/charts/` directory for the overlaid chart, which will be ignored by the `generate-patch` script either way.