### PR TITLE
Add upstream Longhorn chart

### DIFF
--- a/packages/longhorn/package.yaml
+++ b/packages/longhorn/package.yaml
@@ -1,0 +1,2 @@
+url: https://github.com/longhorn/charts/releases/download/longhorn-1.0.0/longhorn-1.0.0.tgz
+packageVersion: 00


### PR DESCRIPTION
This PR adds the chart for Longhorn to `dev-charts` as an Rancher modified chart as requested in rancher/rancher#27725 and longhorn/longhorn#1043.