### PR TITLE
Remove timestamps from patches

### DIFF
--- a/packages/coredns/coredns.patch
+++ b/packages/coredns/coredns.patch
@@ -1,6 +1,17 @@
-diff -uNr packages/coredns/charts-original/templates/configmap.yaml packages/coredns/charts/templates/configmap.yaml
---- packages/coredns/charts-original/templates/configmap.yaml	1970-01-01 02:00:00.000000000 +0200
-+++ packages/coredns/charts/templates/configmap.yaml	2020-05-19 23:46:53.326737422 +0200
+diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/_helpers.tpl packages/coredns/charts/templates/_helpers.tpl
+--- packages/coredns/charts-original/templates/_helpers.tpl	1969-12-31 16:00:00.000000000 -0800
++++ packages/coredns/charts/templates/_helpers.tpl	2020-07-21 11:08:20.000000000 -0700
+@@ -137,6 +137,7 @@
+     {{- end -}}
+ {{- end -}}
+ 
++
+ {{/*
+ Create the name of the service account to use
+ */}}
+diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/configmap.yaml packages/coredns/charts/templates/configmap.yaml
+--- packages/coredns/charts-original/templates/configmap.yaml	1969-12-31 16:00:00.000000000 -0800
++++ packages/coredns/charts/templates/configmap.yaml	2020-07-21 11:08:20.000000000 -0700
 @@ -19,7 +19,7 @@
      {{- if .port }}:{{ .port }} {{ end -}}
      {
@@ -10,20 +21,9 @@ diff -uNr packages/coredns/charts-original/templates/configmap.yaml packages/cor
  {{ .configBlock | indent 12 }}
          }{{ end }}
        {{- end }}
-diff -uNr packages/coredns/charts-original/templates/_helpers.tpl packages/coredns/charts/templates/_helpers.tpl
---- packages/coredns/charts-original/templates/_helpers.tpl	1970-01-01 02:00:00.000000000 +0200
-+++ packages/coredns/charts/templates/_helpers.tpl	2020-05-19 23:46:53.326737422 +0200
-@@ -137,6 +137,7 @@
-     {{- end -}}
- {{- end -}}
- 
-+
- {{/*
- Create the name of the service account to use
- */}}
-diff -uNr packages/coredns/charts-original/templates/service.yaml packages/coredns/charts/templates/service.yaml
---- packages/coredns/charts-original/templates/service.yaml	1970-01-01 02:00:00.000000000 +0200
-+++ packages/coredns/charts/templates/service.yaml	2020-05-19 23:46:53.326737422 +0200
+diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/service.yaml packages/coredns/charts/templates/service.yaml
+--- packages/coredns/charts-original/templates/service.yaml	1969-12-31 16:00:00.000000000 -0800
++++ packages/coredns/charts/templates/service.yaml	2020-07-21 11:08:20.000000000 -0700
 @@ -26,6 +26,8 @@
      app.kubernetes.io/name: {{ template "coredns.name" . }}
    {{- if .Values.service.clusterIP }}
@@ -33,9 +33,9 @@ diff -uNr packages/coredns/charts-original/templates/service.yaml packages/cored
    {{- end }}
    {{- if .Values.service.externalTrafficPolicy }}
    externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
-diff -uNr packages/coredns/charts-original/values.yaml packages/coredns/charts/values.yaml
---- packages/coredns/charts-original/values.yaml	1970-01-01 02:00:00.000000000 +0200
-+++ packages/coredns/charts/values.yaml	2020-06-03 20:25:50.581449545 +0200
+diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/values.yaml packages/coredns/charts/values.yaml
+--- packages/coredns/charts-original/values.yaml	1969-12-31 16:00:00.000000000 -0800
++++ packages/coredns/charts/values.yaml	2020-07-21 11:08:20.000000000 -0700
 @@ -3,8 +3,8 @@
  # Declare variables to be passed into your templates.
  

--- a/packages/coredns/coredns.patch
+++ b/packages/coredns/coredns.patch
@@ -1,6 +1,6 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/_helpers.tpl packages/coredns/charts/templates/_helpers.tpl
---- packages/coredns/charts-original/templates/_helpers.tpl	1969-12-31 16:00:00.000000000 -0800
-+++ packages/coredns/charts/templates/_helpers.tpl	2020-07-21 11:08:20.000000000 -0700
+--- packages/coredns/charts-original/templates/_helpers.tpl
++++ packages/coredns/charts/templates/_helpers.tpl
 @@ -137,6 +137,7 @@
      {{- end -}}
  {{- end -}}
@@ -10,8 +10,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/_hel
  Create the name of the service account to use
  */}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/configmap.yaml packages/coredns/charts/templates/configmap.yaml
---- packages/coredns/charts-original/templates/configmap.yaml	1969-12-31 16:00:00.000000000 -0800
-+++ packages/coredns/charts/templates/configmap.yaml	2020-07-21 11:08:20.000000000 -0700
+--- packages/coredns/charts-original/templates/configmap.yaml
++++ packages/coredns/charts/templates/configmap.yaml
 @@ -19,7 +19,7 @@
      {{- if .port }}:{{ .port }} {{ end -}}
      {
@@ -22,8 +22,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/conf
          }{{ end }}
        {{- end }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/service.yaml packages/coredns/charts/templates/service.yaml
---- packages/coredns/charts-original/templates/service.yaml	1969-12-31 16:00:00.000000000 -0800
-+++ packages/coredns/charts/templates/service.yaml	2020-07-21 11:08:20.000000000 -0700
+--- packages/coredns/charts-original/templates/service.yaml
++++ packages/coredns/charts/templates/service.yaml
 @@ -26,6 +26,8 @@
      app.kubernetes.io/name: {{ template "coredns.name" . }}
    {{- if .Values.service.clusterIP }}
@@ -34,8 +34,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/templates/serv
    {{- if .Values.service.externalTrafficPolicy }}
    externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/coredns/charts-original/values.yaml packages/coredns/charts/values.yaml
---- packages/coredns/charts-original/values.yaml	1969-12-31 16:00:00.000000000 -0800
-+++ packages/coredns/charts/values.yaml	2020-07-21 11:08:20.000000000 -0700
+--- packages/coredns/charts-original/values.yaml
++++ packages/coredns/charts/values.yaml
 @@ -3,8 +3,8 @@
  # Declare variables to be passed into your templates.
  

--- a/packages/metrics-server/metrics-server.patch
+++ b/packages/metrics-server/metrics-server.patch
@@ -1,6 +1,6 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/metrics-server/charts-original/values.yaml packages/metrics-server/charts/values.yaml
---- packages/metrics-server/charts-original/values.yaml	1969-12-31 16:00:00.000000000 -0800
-+++ packages/metrics-server/charts/values.yaml	2020-07-21 11:08:20.000000000 -0700
+--- packages/metrics-server/charts-original/values.yaml
++++ packages/metrics-server/charts/values.yaml
 @@ -27,7 +27,7 @@
    enabled: false
  

--- a/packages/metrics-server/metrics-server.patch
+++ b/packages/metrics-server/metrics-server.patch
@@ -1,6 +1,6 @@
-diff -uNr packages/metrics-server/charts-original/values.yaml packages/metrics-server/charts/values.yaml
---- packages/metrics-server/charts-original/values.yaml	1970-01-01 02:00:00.000000000 +0200
-+++ packages/metrics-server/charts/values.yaml	2020-06-03 20:27:22.848347803 +0200
+diff -x '*.tgz' -x '*.lock' -uNr packages/metrics-server/charts-original/values.yaml packages/metrics-server/charts/values.yaml
+--- packages/metrics-server/charts-original/values.yaml	1969-12-31 16:00:00.000000000 -0800
++++ packages/metrics-server/charts/values.yaml	2020-07-21 11:08:20.000000000 -0700
 @@ -27,7 +27,7 @@
    enabled: false
  

--- a/packages/nginx-ingress/nginx-ingress.patch
+++ b/packages/nginx-ingress/nginx-ingress.patch
@@ -1,6 +1,6 @@
-diff -uNr packages/nginx-ingress/charts-original/values.yaml packages/nginx-ingress/charts/values.yaml
---- packages/nginx-ingress/charts-original/values.yaml	1970-01-01 02:00:00.000000000 +0200
-+++ packages/nginx-ingress/charts/values.yaml	2020-06-26 20:42:28.960654880 +0200
+diff -x '*.tgz' -x '*.lock' -uNr packages/nginx-ingress/charts-original/values.yaml packages/nginx-ingress/charts/values.yaml
+--- packages/nginx-ingress/charts-original/values.yaml	1969-12-31 16:00:00.000000000 -0800
++++ packages/nginx-ingress/charts/values.yaml	2020-07-21 11:08:20.000000000 -0700
 @@ -37,7 +37,7 @@
    # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
    # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920

--- a/packages/nginx-ingress/nginx-ingress.patch
+++ b/packages/nginx-ingress/nginx-ingress.patch
@@ -1,6 +1,6 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/nginx-ingress/charts-original/values.yaml packages/nginx-ingress/charts/values.yaml
---- packages/nginx-ingress/charts-original/values.yaml	1969-12-31 16:00:00.000000000 -0800
-+++ packages/nginx-ingress/charts/values.yaml	2020-07-21 11:08:20.000000000 -0700
+--- packages/nginx-ingress/charts-original/values.yaml
++++ packages/nginx-ingress/charts/values.yaml
 @@ -37,7 +37,7 @@
    # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
    # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920

--- a/packages/rancher-gatekeeper-operator/rancher-gatekeeper-operator.patch
+++ b/packages/rancher-gatekeeper-operator/rancher-gatekeeper-operator.patch
@@ -1,6 +1,6 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/Chart.yaml packages/rancher-gatekeeper-operator/charts/Chart.yaml
---- packages/rancher-gatekeeper-operator/charts-original/Chart.yaml	2020-07-20 21:23:45.618511797 -0700
-+++ packages/rancher-gatekeeper-operator/charts/Chart.yaml	2020-07-20 21:23:31.393490674 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/Chart.yaml	2020-07-21 11:08:32.000000000 -0700
++++ packages/rancher-gatekeeper-operator/charts/Chart.yaml	2020-07-21 11:08:23.000000000 -0700
 @@ -1,10 +1,12 @@
  apiVersion: v1
  description: A Helm chart for Gatekeeper
@@ -17,8 +17,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +annotations:
 +  io.rancher.certified: experimental
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/helm-modifications/helm-modifications.yaml packages/rancher-gatekeeper-operator/charts/helm-modifications/helm-modifications.yaml
---- packages/rancher-gatekeeper-operator/charts-original/helm-modifications/helm-modifications.yaml	2020-07-20 21:23:45.618511797 -0700
-+++ packages/rancher-gatekeeper-operator/charts/helm-modifications/helm-modifications.yaml	1969-12-31 17:00:00.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/helm-modifications/helm-modifications.yaml	2020-07-21 11:08:32.000000000 -0700
++++ packages/rancher-gatekeeper-operator/charts/helm-modifications/helm-modifications.yaml	1969-12-31 16:00:00.000000000 -0800
 @@ -1,61 +0,0 @@
 -apiVersion: v1
 -kind: Service
@@ -82,8 +82,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 -          resources: HELMSUBST_DEPLOYMENT_CONTAINER_RESOURCES
 -      nodeSelector: HELMSUBST_DEPLOYMENT_POD_SCHEDULING
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/helm-modifications/kustomization.yaml packages/rancher-gatekeeper-operator/charts/helm-modifications/kustomization.yaml
---- packages/rancher-gatekeeper-operator/charts-original/helm-modifications/kustomization.yaml	2020-07-20 21:23:45.618511797 -0700
-+++ packages/rancher-gatekeeper-operator/charts/helm-modifications/kustomization.yaml	1969-12-31 17:00:00.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/helm-modifications/kustomization.yaml	2020-07-21 11:08:32.000000000 -0700
++++ packages/rancher-gatekeeper-operator/charts/helm-modifications/kustomization.yaml	1969-12-31 16:00:00.000000000 -0800
 @@ -1,9 +0,0 @@
 -commonLabels:
 -  app: '{{ template "gatekeeper-operator.name" . }}'
@@ -94,9 +94,24 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 -  - _temp.yaml
 -patchesStrategicMerge:
 -  - helm-modifications.yaml
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/_helpers.tpl packages/rancher-gatekeeper-operator/charts/templates/_helpers.tpl
+--- packages/rancher-gatekeeper-operator/charts-original/templates/_helpers.tpl	2020-07-21 11:08:32.000000000 -0700
++++ packages/rancher-gatekeeper-operator/charts/templates/_helpers.tpl	2020-07-21 11:08:23.000000000 -0700
+@@ -42,3 +42,11 @@
+ {{- end }}
+ app.kubernetes.io/managed-by: {{ .Release.Service }}
+ {{- end -}}
++
++{{- define "system_default_registry" -}}
++{{- if .Values.global.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
++{{- else -}}
++{{- "" -}}
++{{- end -}}
++{{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/allowedrepos.yaml packages/rancher-gatekeeper-operator/charts/templates/allowedrepos.yaml
---- packages/rancher-gatekeeper-operator/charts-original/templates/allowedrepos.yaml	1969-12-31 17:00:00.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/templates/allowedrepos.yaml	2020-07-20 21:18:58.371378100 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/allowedrepos.yaml	1969-12-31 16:00:00.000000000 -0800
++++ packages/rancher-gatekeeper-operator/charts/templates/allowedrepos.yaml	2020-07-21 11:08:23.000000000 -0700
 @@ -0,0 +1,35 @@
 +apiVersion: templates.gatekeeper.sh/v1beta1
 +kind: ConstraintTemplate
@@ -135,8 +150,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +        }
 \ No newline at end of file
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/gatekeeper.yaml packages/rancher-gatekeeper-operator/charts/templates/gatekeeper.yaml
---- packages/rancher-gatekeeper-operator/charts-original/templates/gatekeeper.yaml	2020-07-20 21:23:45.618511797 -0700
-+++ packages/rancher-gatekeeper-operator/charts/templates/gatekeeper.yaml	2020-07-20 21:18:58.371378100 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/gatekeeper.yaml	2020-07-21 11:08:32.000000000 -0700
++++ packages/rancher-gatekeeper-operator/charts/templates/gatekeeper.yaml	2020-07-21 11:08:23.000000000 -0700
 @@ -485,7 +485,7 @@
            valueFrom:
              fieldRef:
@@ -155,24 +170,9 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
  {{ toYaml .Values.nodeSelector | indent 8 }}
        affinity:
  {{ toYaml .Values.affinity | indent 8 }}
-diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/_helpers.tpl packages/rancher-gatekeeper-operator/charts/templates/_helpers.tpl
---- packages/rancher-gatekeeper-operator/charts-original/templates/_helpers.tpl	2020-07-20 21:23:45.618511797 -0700
-+++ packages/rancher-gatekeeper-operator/charts/templates/_helpers.tpl	2020-07-20 21:18:58.371378100 -0700
-@@ -42,3 +42,11 @@
- {{- end }}
- app.kubernetes.io/managed-by: {{ .Release.Service }}
- {{- end -}}
-+
-+{{- define "system_default_registry" -}}
-+{{- if .Values.global.systemDefaultRegistry -}}
-+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
-+{{- else -}}
-+{{- "" -}}
-+{{- end -}}
-+{{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/job-constraints-crd.yaml packages/rancher-gatekeeper-operator/charts/templates/job-constraints-crd.yaml
---- packages/rancher-gatekeeper-operator/charts-original/templates/job-constraints-crd.yaml	1969-12-31 17:00:00.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/templates/job-constraints-crd.yaml	2020-07-20 21:18:58.371378100 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/job-constraints-crd.yaml	1969-12-31 16:00:00.000000000 -0800
++++ packages/rancher-gatekeeper-operator/charts/templates/job-constraints-crd.yaml	2020-07-21 11:08:23.000000000 -0700
 @@ -0,0 +1,19 @@
 +apiVersion: batch/v1
 +kind: Job
@@ -195,8 +195,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +  backoffLimit: 1
 \ No newline at end of file
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/requiredlabels.yaml packages/rancher-gatekeeper-operator/charts/templates/requiredlabels.yaml
---- packages/rancher-gatekeeper-operator/charts-original/templates/requiredlabels.yaml	1969-12-31 17:00:00.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/templates/requiredlabels.yaml	2020-07-20 21:18:58.371378100 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/requiredlabels.yaml	1969-12-31 16:00:00.000000000 -0800
++++ packages/rancher-gatekeeper-operator/charts/templates/requiredlabels.yaml	2020-07-21 11:08:23.000000000 -0700
 @@ -0,0 +1,57 @@
 +apiVersion: templates.gatekeeper.sh/v1beta1
 +kind: ConstraintTemplate
@@ -257,8 +257,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +        }
 \ No newline at end of file
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/values.yaml packages/rancher-gatekeeper-operator/charts/values.yaml
---- packages/rancher-gatekeeper-operator/charts-original/values.yaml	2020-07-20 21:23:45.618511797 -0700
-+++ packages/rancher-gatekeeper-operator/charts/values.yaml	2020-07-20 21:18:58.371378100 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/values.yaml	2020-07-21 11:08:32.000000000 -0700
++++ packages/rancher-gatekeeper-operator/charts/values.yaml	2020-07-21 11:08:23.000000000 -0700
 @@ -1,12 +1,12 @@
  replicas: 1
 -auditInterval: 60

--- a/packages/rancher-gatekeeper-operator/rancher-gatekeeper-operator.patch
+++ b/packages/rancher-gatekeeper-operator/rancher-gatekeeper-operator.patch
@@ -1,6 +1,6 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/Chart.yaml packages/rancher-gatekeeper-operator/charts/Chart.yaml
---- packages/rancher-gatekeeper-operator/charts-original/Chart.yaml	2020-07-21 11:08:32.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/Chart.yaml	2020-07-21 11:08:23.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/Chart.yaml
++++ packages/rancher-gatekeeper-operator/charts/Chart.yaml
 @@ -1,10 +1,12 @@
  apiVersion: v1
  description: A Helm chart for Gatekeeper
@@ -17,8 +17,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +annotations:
 +  io.rancher.certified: experimental
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/helm-modifications/helm-modifications.yaml packages/rancher-gatekeeper-operator/charts/helm-modifications/helm-modifications.yaml
---- packages/rancher-gatekeeper-operator/charts-original/helm-modifications/helm-modifications.yaml	2020-07-21 11:08:32.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/helm-modifications/helm-modifications.yaml	1969-12-31 16:00:00.000000000 -0800
+--- packages/rancher-gatekeeper-operator/charts-original/helm-modifications/helm-modifications.yaml
++++ packages/rancher-gatekeeper-operator/charts/helm-modifications/helm-modifications.yaml
 @@ -1,61 +0,0 @@
 -apiVersion: v1
 -kind: Service
@@ -82,8 +82,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 -          resources: HELMSUBST_DEPLOYMENT_CONTAINER_RESOURCES
 -      nodeSelector: HELMSUBST_DEPLOYMENT_POD_SCHEDULING
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/helm-modifications/kustomization.yaml packages/rancher-gatekeeper-operator/charts/helm-modifications/kustomization.yaml
---- packages/rancher-gatekeeper-operator/charts-original/helm-modifications/kustomization.yaml	2020-07-21 11:08:32.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/helm-modifications/kustomization.yaml	1969-12-31 16:00:00.000000000 -0800
+--- packages/rancher-gatekeeper-operator/charts-original/helm-modifications/kustomization.yaml
++++ packages/rancher-gatekeeper-operator/charts/helm-modifications/kustomization.yaml
 @@ -1,9 +0,0 @@
 -commonLabels:
 -  app: '{{ template "gatekeeper-operator.name" . }}'
@@ -95,8 +95,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 -patchesStrategicMerge:
 -  - helm-modifications.yaml
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/_helpers.tpl packages/rancher-gatekeeper-operator/charts/templates/_helpers.tpl
---- packages/rancher-gatekeeper-operator/charts-original/templates/_helpers.tpl	2020-07-21 11:08:32.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/templates/_helpers.tpl	2020-07-21 11:08:23.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/_helpers.tpl
++++ packages/rancher-gatekeeper-operator/charts/templates/_helpers.tpl
 @@ -42,3 +42,11 @@
  {{- end }}
  app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -110,8 +110,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +{{- end -}}
 +{{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/allowedrepos.yaml packages/rancher-gatekeeper-operator/charts/templates/allowedrepos.yaml
---- packages/rancher-gatekeeper-operator/charts-original/templates/allowedrepos.yaml	1969-12-31 16:00:00.000000000 -0800
-+++ packages/rancher-gatekeeper-operator/charts/templates/allowedrepos.yaml	2020-07-21 11:08:23.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/allowedrepos.yaml
++++ packages/rancher-gatekeeper-operator/charts/templates/allowedrepos.yaml
 @@ -0,0 +1,35 @@
 +apiVersion: templates.gatekeeper.sh/v1beta1
 +kind: ConstraintTemplate
@@ -150,8 +150,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +        }
 \ No newline at end of file
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/gatekeeper.yaml packages/rancher-gatekeeper-operator/charts/templates/gatekeeper.yaml
---- packages/rancher-gatekeeper-operator/charts-original/templates/gatekeeper.yaml	2020-07-21 11:08:32.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/templates/gatekeeper.yaml	2020-07-21 11:08:23.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/gatekeeper.yaml
++++ packages/rancher-gatekeeper-operator/charts/templates/gatekeeper.yaml
 @@ -485,7 +485,7 @@
            valueFrom:
              fieldRef:
@@ -171,8 +171,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
        affinity:
  {{ toYaml .Values.affinity | indent 8 }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/job-constraints-crd.yaml packages/rancher-gatekeeper-operator/charts/templates/job-constraints-crd.yaml
---- packages/rancher-gatekeeper-operator/charts-original/templates/job-constraints-crd.yaml	1969-12-31 16:00:00.000000000 -0800
-+++ packages/rancher-gatekeeper-operator/charts/templates/job-constraints-crd.yaml	2020-07-21 11:08:23.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/job-constraints-crd.yaml
++++ packages/rancher-gatekeeper-operator/charts/templates/job-constraints-crd.yaml
 @@ -0,0 +1,19 @@
 +apiVersion: batch/v1
 +kind: Job
@@ -195,8 +195,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +  backoffLimit: 1
 \ No newline at end of file
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/templates/requiredlabels.yaml packages/rancher-gatekeeper-operator/charts/templates/requiredlabels.yaml
---- packages/rancher-gatekeeper-operator/charts-original/templates/requiredlabels.yaml	1969-12-31 16:00:00.000000000 -0800
-+++ packages/rancher-gatekeeper-operator/charts/templates/requiredlabels.yaml	2020-07-21 11:08:23.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/templates/requiredlabels.yaml
++++ packages/rancher-gatekeeper-operator/charts/templates/requiredlabels.yaml
 @@ -0,0 +1,57 @@
 +apiVersion: templates.gatekeeper.sh/v1beta1
 +kind: ConstraintTemplate
@@ -257,8 +257,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-ori
 +        }
 \ No newline at end of file
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper-operator/charts-original/values.yaml packages/rancher-gatekeeper-operator/charts/values.yaml
---- packages/rancher-gatekeeper-operator/charts-original/values.yaml	2020-07-21 11:08:32.000000000 -0700
-+++ packages/rancher-gatekeeper-operator/charts/values.yaml	2020-07-21 11:08:23.000000000 -0700
+--- packages/rancher-gatekeeper-operator/charts-original/values.yaml
++++ packages/rancher-gatekeeper-operator/charts/values.yaml
 @@ -1,12 +1,12 @@
  replicas: 1
 -auditInterval: 60

--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -23,6 +23,7 @@ for f in packages/*; do
 				cp -r /tmp/tmp-charts/${subdirectory} ${f}/charts-original
 				rm -rf /tmp/tmp-charts
 			else
+				mkdir -p ${f}/charts-original
 				curl -sLf ${url} | tar xvzf - -C ${f}/charts-original --strip ${fields} ${subdirectory} > /dev/null 2>&1
 			fi
 			if [[ -d ${f}/charts ]]; then

--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -2,6 +2,18 @@
 set -e
 set -x
 
+function remove_timestamp_from_diff {
+	prefix="[-\+]\{3\}"
+	filename_format="packages\/$(basename -- ${f})\/[^[:space:]]*"
+	# https://www.gnu.org/software/diffutils/manual/html_node/Example-Unified.html#Example-Unified
+	# Example timestamp: 2002-02-21 23:30:39.942229878 -0800
+	date="[[:digit:]]\{4\}-[[:digit:]]\{2\}-[[:digit:]]\{2\}"
+	time="[[:digit:]]\{2\}:[[:digit:]]\{2\}:[[:digit:]]\{2\}.[[:digit:]]\{9\}"
+	timezone="[-\+][[:digit:]]\{4\}"
+	timestamp_format="${date}[[:space:]]${time}[[:space:]]${timezone}"
+	sed -i '' "s/\(${prefix} ${filename_format}\)[[:space:]]${timestamp_format}/\1/" ${f}/$(basename -- ${f}).patch
+}
+
 for f in packages/*; do
   if [[ -f ${f}/package.yaml ]]; then
   	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
@@ -28,6 +40,7 @@ for f in packages/*; do
 			fi
 			if [[ -d ${f}/charts ]]; then
 				diff -x *.tgz -x *.lock -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
+				remove_timestamp_from_diff
 			fi
 			rm -rf ${f}/charts-original
 		fi


### PR DESCRIPTION
This PR modifies the `generate-patch` script to remove the timestamps created from the patch.

Consists of 4 commits:
- Nit: fix for making the chart-original directory (fix for coredns package)
- Regenerate all patches for all packages using the old `generate-patch` script with `make prepare; make patch; make clean`
    - No actual changes seem to have been made; some patches got moved around though
- Update the `generate-patch` script to remove timestamps after calculating the diff
- Output from `make prepare; make patch; make clean` in the new script

Tested out running `make prepare` on the new timestamps and it works as expected.

Related Issue: https://github.com/rancher/dev-charts/issues/36