### PR TITLE
Fix logging template errors on chart install

### DIFF
--- a/packages/rancher-logging/overlay/templates/flow.yaml
+++ b/packages/rancher-logging/overlay/templates/flow.yaml
@@ -4,7 +4,7 @@ kind: ClusterFlow
 metadata:
   name: {{ .Release.Name }}
   labels:
-{{ include "rancher-logging.labels" . | indent 4 }}
+{{ include "logging-operator.labels" . | indent 4 }}
 spec:
   outputRefs:
     - {{ .Release.Name }}-elasticsearch

--- a/packages/rancher-logging/overlay/templates/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/logging.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "rancher-logging.labels" . | indent 4 }}
+{{ include "logging-operator.labels" . | indent 4 }}
 spec:
   controlNamespace: {{ .Release.Namespace }}
   fluentbit: {}

--- a/packages/rancher-logging/overlay/templates/outputs/elasticsearch/secret.yaml
+++ b/packages/rancher-logging/overlay/templates/outputs/elasticsearch/secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-elasticsearch
   labels:
-{{ include "rancher-logging.labels" . | indent 4 }}
+{{ include "logging-operator.labels" . | indent 4 }}
 type: Opaque
 data:
   password: {{ .Values.elasticsearch.password | b64enc | quote }}


### PR DESCRIPTION
ISSSUE:
when installing the helm chart with a configured elastic output the chart would error out with template changes

CAUSE:
a heavy handed find and replace broke some include statements

SOLUTION:
fixed the include statements to use the correct variable